### PR TITLE
Refined description of what happens when you call init multiple times

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -98,7 +98,7 @@ For now, let's grab the first element out of this list and assign it to a variab
 
     alice = people[0]
 
-.. note:: It is a very bad idea to call `init` more than once on a single field. Every call to `init` allocates new memory inside your Cap'n Proto message, and if you call it more than once, the previous memory is leaked.
+.. note:: It is a very bad idea to call `init` more than once on a single field. Every call to `init` allocates new memory inside your Cap'n Proto message, and if you call it more than once, the previous memory is left as dead space in the message. See `https://capnproto.org/cxx.html#tips-and-best-practices <Chapter about Tips and Best Practices> for more details`_.
 
 Primitive Types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -98,7 +98,7 @@ For now, let's grab the first element out of this list and assign it to a variab
 
     alice = people[0]
 
-.. note:: It is a very bad idea to call `init` more than once on a single field. Every call to `init` allocates new memory inside your Cap'n Proto message, and if you call it more than once, the previous memory is left as dead space in the message. See `https://capnproto.org/cxx.html#tips-and-best-practices <Tips and Best Practices>`_ for more details.
+.. note:: It is a very bad idea to call `init` more than once on a single field. Every call to `init` allocates new memory inside your Cap'n Proto message, and if you call it more than once, the previous memory is left as dead space in the message. See `Tips and Best Practices <https://capnproto.org/cxx.html#tips-and-best-practices>`_ for more details.
 
 Primitive Types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -98,7 +98,7 @@ For now, let's grab the first element out of this list and assign it to a variab
 
     alice = people[0]
 
-.. note:: It is a very bad idea to call `init` more than once on a single field. Every call to `init` allocates new memory inside your Cap'n Proto message, and if you call it more than once, the previous memory is left as dead space in the message. See `https://capnproto.org/cxx.html#tips-and-best-practices <Chapter about Tips and Best Practices> for more details`_.
+.. note:: It is a very bad idea to call `init` more than once on a single field. Every call to `init` allocates new memory inside your Cap'n Proto message, and if you call it more than once, the previous memory is left as dead space in the message. See `https://capnproto.org/cxx.html#tips-and-best-practices <Tips and Best Practices>`_ for more details.
 
 Primitive Types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The original note was misleading in that it implied an actual memory leakage (in the common sense of the term). This is not the case though since the memory is left as dead space in the message but is always correctly freed upon freeing the arena.